### PR TITLE
Fix list render and add list parser

### DIFF
--- a/list_paragraph.py
+++ b/list_paragraph.py
@@ -1,34 +1,57 @@
+import re
 from paragraph import Paragraph
 
 
 class ListParagraph(Paragraph):
-    def __init__(self, content, is_ordered, is_start=None, is_end=None):
+    def __init__(self, content, is_ordered):
         super().__init__(content)
         self._is_ordered = is_ordered
-        self._is_start = is_start
-        self._is_end = is_end
 
     def render(self) -> str:
-        item = f"<li>{self.content()}</li>"
-        if self._is_start is None and self._is_end is None:
-            return item
-        elif self._is_start:
-            return f"<ol>{item}" if self._is_ordered else f"<ul>{item}"
-        elif self._is_end:
-            return f"{item}</ol>" if self._is_ordered else f"{item}</ul>"
+        return f"<li>{self.content()}</li>"
 
 
 class OrderedList(ListParagraph):
     """Line starting with number
     """
 
-    def __init__(self, content, is_start, is_end):
-        super().__init__(content, True, is_start, is_end)
+    def __init__(self, content):
+        super().__init__(content, True)
+
+    @staticmethod
+    def parse(content) -> (int, int, 'OrderedList'):
+        """Parse a list paragraph, and return (begin, end, OrderedList) if parseable,
+        or (-1, -1, None) that no such a element
+        """
+        pattern = r'^[ ]*\d\.[ ]+(.*)$'
+        matches = re.search(pattern, content)
+        if matches:
+            return (
+                matches.start(),
+                matches.end(),
+                OrderedList(
+                    matches.group(1)))
+        return (-1, -1, None)
 
 
 class UnorderedList(ListParagraph):
     """Line starting with '-', '*' or '+'
     """
 
-    def __init__(self, content, is_start, is_end):
-        super().__init__(content, False, is_start, is_end)
+    def __init__(self, content):
+        super().__init__(content, False)
+
+    @staticmethod
+    def parse(content) -> (int, int, 'UnorderedList'):
+        """Parse a list paragraph, and return (begin, end, UnorderedList) if parseable,
+        or (-1, -1, None) that no such a element
+        """
+        pattern = r'^[ ]*(?:\*|\-|\+)[ ]+(.*)$'
+        matches = re.search(pattern, content)
+        if matches:
+            return (
+                matches.start(),
+                matches.end(),
+                UnorderedList(
+                    matches.group(1)))
+        return (-1, -1, None)

--- a/list_paragraph_test.py
+++ b/list_paragraph_test.py
@@ -2,21 +2,74 @@ import pytest
 from list_paragraph import OrderedList, UnorderedList
 
 
-@pytest.mark.parametrize("content, is_start, is_end, html", [
-    ("first item", True, None, "<ol><li>first item</li>"),
-    ("second item", None, None, "<li>second item</li>"),
-    ("last item", None, True, "<li>last item</li></ol>")
+@pytest.mark.parametrize("content, html", [
+    ("first item", "<li>first item</li>"),
+    (" second item", "<li> second item</li>")
 ])
-def test_ordered_render(content, is_start, is_end, html):
-    ordered_list = OrderedList(content, is_start, is_end)
+def test_ordered_render(content, html):
+    ordered_list = OrderedList(content)
     assert html == ordered_list.render()
 
 
-@pytest.mark.parametrize("content, is_start, is_end, html", [
-    ("first item", True, None, "<ul><li>first item</li>"),
-    ("second item", None, None, "<li>second item</li>"),
-    ("last item", None, True, "<li>last item</li></ul>")
+@pytest.mark.parametrize("content, expected_start, expected_end, html", [
+    ("1. first item", 0, 13, "<li>first item</li>"),
+    ("1.  first item", 0, 14, "<li>first item</li>"),
+    ("  1. first item", 0, 15, "<li>first item</li>")
 ])
-def test_unordered_render(content, is_start, is_end, html):
-    unordered_list = UnorderedList(content, is_start, is_end)
+def test_ordered_parse(content, expected_start, expected_end, html):
+    start, end, ordered_list = OrderedList.parse(content)
+    assert expected_start == start
+    assert expected_end == end
+    assert ordered_list is not None
+    assert html == ordered_list.render()
+
+
+@pytest.mark.parametrize("content", [
+    ("not a list"),
+    (r"1\. first item"),
+    ("1 first item"),
+    ("1.first item"),
+    ("1, first item"),
+    ("aa1. first item"),
+])
+def test_ordered_parse_failed(content):
+    start, end, ordered_list = OrderedList.parse(content)
+    assert start == end == -1
+    assert ordered_list is None
+
+
+@pytest.mark.parametrize("content, html", [
+    ("first item", "<li>first item</li>"),
+    ("second item ", "<li>second item </li>")
+])
+def test_unordered_render(content, html):
+    unordered_list = UnorderedList(content)
     assert html == unordered_list.render()
+
+
+@pytest.mark.parametrize("content, expected_start, expected_end, html", [
+    ("* first item", 0, 12, "<li>first item</li>"),
+    ("- first item", 0, 12, "<li>first item</li>"),
+    ("+ first item", 0, 12, "<li>first item</li>"),
+    (" - first item", 0, 13, "<li>first item</li>"),
+    (r"- \-first item", 0, 14, r"<li>\-first item</li>")
+])
+def test_unordered_parse(content, expected_start, expected_end, html):
+    start, end, unordered_list = UnorderedList.parse(content)
+    assert expected_start == start
+    assert expected_end == end
+    assert unordered_list is not None
+    assert html == unordered_list.render()
+
+
+@pytest.mark.parametrize("content", [
+    ("not a list"),
+    (r"-first item"),
+    (r"\-first item"),
+    (r"\-- first item"),
+    ("aa- first item"),
+])
+def test_unordered_parse_failed(content):
+    start, end, unordered_list = UnorderedList.parse(content)
+    assert start == end == -1
+    assert unordered_list is None


### PR DESCRIPTION
- As we discussed last time, remove `is_start` and `is_end` in the render function. This will be done in element merge.
- Add parser for ordered list and unordered list.