### PR TITLE
Add "TextParagraphParser" and "multiple empty line parser"

### DIFF
--- a/src/blocks/__init__.py
+++ b/src/blocks/__init__.py
@@ -3,7 +3,7 @@ from .quote import QuoteParagraph
 from .header import HeaderParagraph
 from .horizontal_rule import HorizontalRule
 from .fenced_code_block import FencedCodeBlock
-from .list_paragraph import OrderedList, UnorderedList, ListParagraph
+from .list_paragraph import OrderedList, UnorderedList, ListParagraph, ListWrapper
 
 # Blocks
 from .block import Block, TextBlock

--- a/src/blocks/element.py
+++ b/src/blocks/element.py
@@ -33,3 +33,6 @@ class Element(object):
         """Could this element hold other elements inside, True for yes.
         """
         return True
+
+    def __eq__(self, value):
+        return isinstance(value, Element) and value.content() == self.content()

--- a/src/blocks/element.py
+++ b/src/blocks/element.py
@@ -39,4 +39,5 @@ class Element(object):
         return True
 
     def __eq__(self, value):
-        return isinstance(value, type(self)) and value.content() == self.content()
+        return isinstance(value,
+                          type(self)) and value.content() == self.content()

--- a/src/blocks/element.py
+++ b/src/blocks/element.py
@@ -12,11 +12,15 @@ class Element(object):
     def content(self):
         return self._content
 
+    @property
     def children(self):
         return self._children
 
-    def add_child(self, child):
-        self._children.append(child)
+    def add_child(self, child, index=None):
+        if not index or index > len(self._children):
+            self._children.append(child)
+        else:
+            self._children.insert(index, child)
 
     @property
     def parent(self):

--- a/src/blocks/element.py
+++ b/src/blocks/element.py
@@ -39,4 +39,4 @@ class Element(object):
         return True
 
     def __eq__(self, value):
-        return isinstance(value, Element) and value.content() == self.content()
+        return isinstance(value, type(self)) and value.content() == self.content()

--- a/src/blocks/list_paragraph.py
+++ b/src/blocks/list_paragraph.py
@@ -19,7 +19,7 @@ class ListWrapper(Paragraph):
         super().__init__(None)
         self._children = content if content else []
         self._is_ordered = is_ordered
-    
+
     def is_ordered(self):
         return self._is_ordered
 

--- a/src/blocks/list_paragraph.py
+++ b/src/blocks/list_paragraph.py
@@ -10,6 +10,26 @@ class ListParagraph(Paragraph):
     def render(self) -> str:
         return f"<li>{self.content()}</li>"
 
+    def is_ordered(self):
+        return self._is_ordered
+
+
+class ListWrapper(Paragraph):
+    def __init__(self, content, is_ordered):
+        super().__init__(None)
+        self._children = content if content else []
+        self._is_ordered = is_ordered
+    
+    def is_ordered(self):
+        return self._is_ordered
+
+    def render(self) -> str:
+        rendered_children = "\n".join((i.render() for i in self._children))
+        if self._is_ordered:
+            return f"<ol>{rendered_children}</ol>"
+        else:
+            return f"<ul>{rendered_children}</ul>"
+
 
 class OrderedList(ListParagraph):
     """Line starting with number

--- a/src/blocks/paragraph.py
+++ b/src/blocks/paragraph.py
@@ -7,4 +7,5 @@ class Paragraph(Element):
 
 
 class TextParagraph(Paragraph):
-    pass
+    def __init__(self, content):
+        super().__init__(content)

--- a/src/blocks/test/list_paragraph_test.py
+++ b/src/blocks/test/list_paragraph_test.py
@@ -18,11 +18,13 @@ def test_unordered_render(content, html):
     assert html == unordered_list.render()
 
 
-@pytest.mark.parametrize("content, ordered, html",
-                         [([OrderedList("first item")], True, "<ol><li>first item</li></ol>"),
-                          ([OrderedList("second item")], False, "<ul><li>second item</li></ul>"),
-                          ([OrderedList("first item"), OrderedList("second item")], False, "<ul><li>first item</li>\n<li>second item</li></ul>"),])
+@pytest.mark.parametrize("content, ordered, html", [
+    ([OrderedList("first item")], True, "<ol><li>first item</li></ol>"),
+    ([OrderedList("second item")], False, "<ul><li>second item</li></ul>"),
+    ([OrderedList("first item"),
+      OrderedList("second item")
+      ], False, "<ul><li>first item</li>\n<li>second item</li></ul>"),
+])
 def test_list_wrapper_render(content, ordered, html):
     list_wrapper = ListWrapper(content, is_ordered=ordered)
-    list_wrapper.children.extend(content)
     assert html == list_wrapper.render()

--- a/src/blocks/test/list_paragraph_test.py
+++ b/src/blocks/test/list_paragraph_test.py
@@ -1,5 +1,5 @@
 import pytest
-from ..list_paragraph import OrderedList, UnorderedList
+from ..list_paragraph import OrderedList, UnorderedList, ListWrapper
 
 
 @pytest.mark.parametrize("content, html",
@@ -16,3 +16,13 @@ def test_ordered_render(content, html):
 def test_unordered_render(content, html):
     unordered_list = UnorderedList(content)
     assert html == unordered_list.render()
+
+
+@pytest.mark.parametrize("content, ordered, html",
+                         [([OrderedList("first item")], True, "<ol><li>first item</li></ol>"),
+                          ([OrderedList("second item")], False, "<ul><li>second item</li></ul>"),
+                          ([OrderedList("first item"), OrderedList("second item")], False, "<ul><li>first item</li>\n<li>second item</li></ul>"),])
+def test_list_wrapper_render(content, ordered, html):
+    list_wrapper = ListWrapper(content, is_ordered=ordered)
+    list_wrapper.children.extend(content)
+    assert html == list_wrapper.render()

--- a/src/parser/horizontal_rule_parser.py
+++ b/src/parser/horizontal_rule_parser.py
@@ -12,9 +12,9 @@ def parse_horiontal_rule(content):
     Note, the index of start and end follow the convention of [start, end)
     Return (-1, -1, None) if no such match found.
     '''
-    pattern = r'^\s*(\*{3,}|-{3,}|_{3,})\s?$'
+    pattern = r'^[^\S\r\n]*(\*{3,}|-{3,}|_{3,})[^\S\r\n]*$\n?'
     matches = re.search(pattern, content, re.MULTILINE)
     if matches:
-        return (matches.start(1), matches.end(1), HorizontalRule(''))
+        return (matches.start(), matches.end(), HorizontalRule(''))
     else:
         return (-1, -1, None)

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -76,13 +76,14 @@ class ParagraphParser(AbstractParser):
             if empty_lines_start == 0:
                 print("here")
                 ## put an empty text paragraph to avoid paragraph merge.
-                start_index, end_index, final_element = empty_lines_start, empty_lines_end, TextParagraph("")
+                start_index, end_index, final_element = empty_lines_start, empty_lines_end, TextParagraph(
+                    "")
                 ## put an empty text paragraph to avoid paragraph merge.
             else:
                 print("here2")
                 start_index, end_index, final_element = self._default(
                     content[:start_index])
-        print ("parsed object", content, final_element)
+        print("parsed object", content, final_element)
         link_parent_and_child(parent, final_element)
         return content[end_index:]
 

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -71,12 +71,11 @@ class ParagraphParser(AbstractParser):
                 start_index, end_index, final_element = begin, end, element
         if start_index > 0:
             # try to eliminate empty lines
-            empty_lines_start, empty_lines_end, _ = parse_empty_newlines(
-                content)
-            if empty_lines_start == 0:
+            begin, end, _ = parse_empty_newlines(content)
+            if begin == 0:
                 print("here")
                 ## put an empty text paragraph to avoid paragraph merge.
-                start_index, end_index, final_element = empty_lines_start, empty_lines_end, TextParagraph(
+                start_index, end_index, final_element = begin, end, TextParagraph(
                     "")
                 ## put an empty text paragraph to avoid paragraph merge.
             else:

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -73,18 +73,15 @@ class ParagraphParser(AbstractParser):
             # try to eliminate empty lines
             begin, end, _ = parse_empty_newlines(content)
             if begin == 0:
-                print("here")
                 ## put an empty text paragraph to avoid paragraph merge.
                 start_index, end_index, final_element = begin, end, TextParagraph(
                     "")
                 ## put an empty text paragraph to avoid paragraph merge.
             else:
-                print("here2")
                 start_index, end_index, final_element = self._default(
                     content[:start_index])
         final_element = self._post_parse_merge_quote(parent, final_element)
         tmp_parent = self._post_parse_merge_list(parent, final_element)
-        print(tmp_parent)
         link_parent_and_child(tmp_parent, final_element)
         return content[end_index:]
 
@@ -109,7 +106,6 @@ class ParagraphParser(AbstractParser):
             return new_element
 
     def _post_parse_merge_list(self, parent, new_element):
-        print(new_element, new_element.render())
         if parent.children and isinstance(new_element, ListParagraph):
             if (isinstance(parent.children[-1], ListWrapper)
                     and parent.children[-1].is_ordered()

--- a/src/parser/quote_parser.py
+++ b/src/parser/quote_parser.py
@@ -6,12 +6,12 @@ def parse_quote(content) -> (int, int, 'QuoteParagraph'):
     """Parse a quote content, and return (begin, end, QuoteParagraph)
     if parseable, or (-1, -1, None) that no such a element
     """
-    pattern = r'^[ ]*\>[ ]*(.*)$'
+    pattern = r'^[ ]*\>[ ]*(.*)$\n?'
 
-    quote_match = re.search(pattern, content)
+    quote_match = re.search(pattern, content, re.MULTILINE)
     if quote_match:
-        start = 0
-        end = len(content)
+        start = quote_match.start()
+        end = quote_match.end()
         content = quote_match.group(1)
         return (start, end, QuoteParagraph(content))
     return (-1, -1, None)

--- a/src/parser/test/parse_horizontal_rule_test.py
+++ b/src/parser/test/parse_horizontal_rule_test.py
@@ -4,14 +4,15 @@ from ..horizontal_rule_parser import parse_horiontal_rule
 
 @pytest.mark.parametrize("content, start, end", [('***', 0, 3), ('____', 0, 4),
                                                  ('-----', 0, 5),
-                                                 (' ------', 1, 7),
-                                                 ('______ ', 0, 6),
+                                                 (' ------', 0, 7),
+                                                 ('______ ', 0, 7),
+                                                 ('______ \n', 0, 8),
                                                  ('''
 
 
 -----
 
-''', 3, 8)])
+''', 3, 9)])
 def test_parse(content, start, end):
     (start_index, end_index, hori_rule) = parse_horiontal_rule(content)
     assert start_index == start

--- a/src/parser/test/parse_text_paragraph_text.py
+++ b/src/parser/test/parse_text_paragraph_text.py
@@ -31,6 +31,9 @@ def test_text_paragraph_parse(content, expected_start, expected_end, expected_ob
     (r"""
 
 """, 0, 2),
+    (r"""
+""", 0, 1),
+    
 ])
 def test_multiple_line_parse(content, expected_start, expected_end):
     start, end, _ = parse_empty_newlines(content)
@@ -38,8 +41,6 @@ def test_multiple_line_parse(content, expected_start, expected_end):
     assert expected_end == end
 
 @pytest.mark.parametrize("content", [
-    (r"""
-    """),
     (r""""""),
 ])
 def test_multiple_line_parse_failed(content):

--- a/src/parser/test/parse_text_paragraph_text.py
+++ b/src/parser/test/parse_text_paragraph_text.py
@@ -33,7 +33,6 @@ def test_text_paragraph_parse(content, expected_start, expected_end, expected_ob
 """, 0, 2),
     (r"""
 """, 0, 1),
-    
 ])
 def test_multiple_line_parse(content, expected_start, expected_end):
     start, end, _ = parse_empty_newlines(content)

--- a/src/parser/test/parse_text_paragraph_text.py
+++ b/src/parser/test/parse_text_paragraph_text.py
@@ -1,0 +1,48 @@
+import pytest
+from ..text_paragraph_parser import parse_text_pargraph, parse_empty_newlines
+from ...blocks.paragraph import TextParagraph
+
+@pytest.mark.parametrize("content, expected_start, expected_end, expected_obj", [
+    (r"""testing text""", 0, 12, TextParagraph("testing text")),
+    (r"""abc
+def
+g
+""", 0, 10, TextParagraph("abcdefg")),
+    (r"""abc
+def
+g
+
+higk
+""", 0, 11, TextParagraph("abcdefg")),
+])
+def test_text_paragraph_parse(content, expected_start, expected_end, expected_obj):
+    start, end, text_paragraph = parse_text_pargraph(content)
+    assert expected_start == start
+    assert expected_end == end
+    assert text_paragraph is not None
+    assert expected_obj == text_paragraph
+
+@pytest.mark.parametrize("content, expected_start, expected_end", [
+    (r"""
+
+
+
+""", 0, 4),
+    (r"""
+
+""", 0, 2),
+])
+def test_multiple_line_parse(content, expected_start, expected_end):
+    start, end, _ = parse_empty_newlines(content)
+    assert expected_start == start
+    assert expected_end == end
+
+@pytest.mark.parametrize("content", [
+    (r"""
+    """),
+    (r""""""),
+])
+def test_multiple_line_parse_failed(content):
+    start, end, _ = parse_empty_newlines(content)
+    assert -1 == start
+    assert -1 == end

--- a/src/parser/test/parser_test.py
+++ b/src/parser/test/parser_test.py
@@ -42,12 +42,17 @@ Test""",
 bala
 >test
 This is a 
-text paragraph""", [TextParagraph("bala"), QuoteParagraph("test"), TextParagraph("This is a text paragraph")])
+text paragraph""", [TextParagraph(""),TextParagraph("bala"), QuoteParagraph("test"), TextParagraph("This is a text paragraph")]),
+(r""">a
+>b""", [QuoteParagraph("a\nb")]),
+(r""">a
+
+>b""", [QuoteParagraph("a"), TextParagraph(""), QuoteParagraph("b")])
 ])
 def test_paragraph_parser(content, expected):
     paragraph_parser = create_paragraph_parsers()
     root = paragraph_parser.parse(content)
-    children = root.children()
+    children = root.children
     assert len(expected) == len(children)
     for i in range(len(children)):
         assert isinstance(expected[i], type(children[i]))
@@ -64,7 +69,7 @@ def test_paragraph_parser(content, expected):
 def test_block_parser(content, expected):
     block_parser = create_block_parsers()
     root = block_parser.parse(content)
-    children = root.children()
+    children = root.children
     assert len(expected) == len(children)
     for i in range(len(children)):
         assert isinstance(expected[i], type(children[i]))
@@ -81,10 +86,10 @@ def test_nested_block_parser():
     }
     root = block_parser.parse(content)
     print(root.render())
-    cur = root.children()
+    cur = root.children
     idx = 0
     while not cur:
         assert isinstance(expected[idx], type(cur[0]))
         assert expected[idx].content() == cur[0].content()
-        cur = cur[0].children()
+        cur = cur[0].children
         idx += 1

--- a/src/parser/test/parser_test.py
+++ b/src/parser/test/parser_test.py
@@ -28,12 +28,6 @@ Test""",
      [TextParagraph("Test"),
       HorizontalRule(""),
       TextParagraph("Test")]),
-    (r"""1. List1
-2. List2
->content""",
-     [OrderedList("List1"),
-      OrderedList("List2"),
-      QuoteParagraph("content")]),
     (r"""
       
       
@@ -43,6 +37,13 @@ bala
 >test
 This is a 
 text paragraph""", [TextParagraph(""),TextParagraph("bala"), QuoteParagraph("test"), TextParagraph("This is a text paragraph")]),
+(r"""1. List1
+2. List2
+>content
+1. List3
+- List4
+""", [ListWrapper([OrderedList("List1"),OrderedList("List2")], True), QuoteParagraph("content"), 
+        ListWrapper([OrderedList("List3")], True), ListWrapper([OrderedList("List4")], False)]),
 (r""">a
 >b""", [QuoteParagraph("a\nb")]),
 (r""">a
@@ -74,7 +75,6 @@ def test_block_parser(content, expected):
     for i in range(len(children)):
         assert isinstance(expected[i], type(children[i]))
         assert expected[i].content() == children[i].content()
-
 
 def test_nested_block_parser():
     block_parser = create_block_parsers()

--- a/src/parser/test/parser_test.py
+++ b/src/parser/test/parser_test.py
@@ -25,15 +25,24 @@ from ...blocks import *
     (r"""Test
 ----
 Test""",
-     [TextParagraph("Test\n"),
+     [TextParagraph("Test"),
       HorizontalRule(""),
-      TextParagraph("\nTest")]),
+      TextParagraph("Test")]),
     (r"""1. List1
 2. List2
 >content""",
      [OrderedList("List1"),
       OrderedList("List2"),
       QuoteParagraph("content")]),
+    (r"""
+      
+      
+      
+      
+bala
+>test
+This is a 
+text paragraph""", [TextParagraph("bala"), QuoteParagraph("test"), TextParagraph("This is a text paragraph")])
 ])
 def test_paragraph_parser(content, expected):
     paragraph_parser = create_paragraph_parsers()

--- a/src/parser/text_paragraph_parser.py
+++ b/src/parser/text_paragraph_parser.py
@@ -1,0 +1,33 @@
+# r"(^.+(\n?))+(\n)?"
+
+import re
+import os
+from ..blocks import TextParagraph
+
+
+def parse_text_pargraph(content) -> (int, int, 'TextParagraph'):
+    """Parse a text paragraph content, and return (begin, end,
+    TextParagraph) if parseable,
+    or (-1, -1, None) that no such a element.
+    """
+    pattern = r"(^.+(\n?))+(\n)?"
+    paragraph_match = re.search(pattern, content, re.MULTILINE)
+    if paragraph_match:
+        full_text = paragraph_match.group(0).replace(
+            os.linesep, "")  # remove all newline in one text paragraph.
+        start = paragraph_match.start()
+        end = paragraph_match.end()
+        return (start, end, TextParagraph(full_text))
+    return (-1, -1, None)
+
+
+def parse_empty_newlines(content) -> (int, int, 'None'):
+    """
+    Parse multiple empty line. If match, return start and end of continous empty lines.
+    or -1, -1, None.
+    """
+    pattern = r"(\s*\n){2,}"
+    empty_line_match = re.search(pattern, content, re.MULTILINE)
+    if empty_line_match and empty_line_match.start() == 0:
+        return (empty_line_match.start(), empty_line_match.end(), None)
+    return -1, -1, None

--- a/src/parser/text_paragraph_parser.py
+++ b/src/parser/text_paragraph_parser.py
@@ -26,7 +26,7 @@ def parse_empty_newlines(content) -> (int, int, 'None'):
     Parse multiple empty line. If match, return start and end of continous empty lines.
     or -1, -1, None.
     """
-    pattern = r"(\s*\n){2,}"
+    pattern = r"(\s*\n)+"
     empty_line_match = re.search(pattern, content, re.MULTILINE)
     if empty_line_match and empty_line_match.start() == 0:
         return (empty_line_match.start(), empty_line_match.end(), None)


### PR DESCRIPTION
Add: 
- Text paragraph parser
- Multiple empty line parser
- Merger of quote

Amend: 
- quote parser enable "multiple line", and return correct begin & end instead of (0, len(content))
- parser logic, now it will try to remove empty lines, and use text paragraph parser to parse unmatched part. 
- regexp of horizontal rule. 
 